### PR TITLE
fix exp type

### DIFF
--- a/engine/claims.go
+++ b/engine/claims.go
@@ -18,7 +18,7 @@ type AuthClaims struct {
 	Issuer     string
 	Subject    string
 	Audience   string
-	Expiration string
+	Expiration float64
 
 	// Scopes see: https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
 	Scopes ScopeSet

--- a/engine/utils/claims.go
+++ b/engine/utils/claims.go
@@ -20,7 +20,7 @@ func AuthClaimsToJwtClaims(raw engine.AuthClaims) jwtV5.Claims {
 	if raw.Audience != "" {
 		claims["aud"] = raw.Audience
 	}
-	if raw.Expiration != "" {
+	if raw.Expiration != 0 {
 		claims["exp"] = raw.Expiration
 	}
 
@@ -67,7 +67,7 @@ func MapClaimsToAuthClaims(rawClaims jwtV5.MapClaims) (*engine.AuthClaims, error
 	}
 	// optional Expiration
 	if expirationClaim, ok := rawClaims["exp"]; ok {
-		if claims.Expiration, ok = expirationClaim.(string); !ok {
+		if claims.Expiration, ok = expirationClaim.(float64); !ok {
 			return nil, engine.ErrInvalidExpiration
 		}
 	}


### PR DESCRIPTION
In v5 of jwt package there is a validation for Expiration field (not only ) and should be of type [NumericDate ](https://github.com/golang-jwt/jwt/blob/bc8bdca5cced1caa9787e4a1c313a3538544c877/map_claims.go#L45)so claim like
{ "exp":"1732820690" }
is not longer valid. Should be
{ "exp":1732820690 }
So if set Expiration now and try to verify it you will get invalid jwt token returned from the jwt package