### PR TITLE
Change WithKey function parameter type to interface{}

### DIFF
--- a/engine/jwt/options.go
+++ b/engine/jwt/options.go
@@ -19,7 +19,7 @@ func WithSigningMethod(alg string) Option {
 }
 
 // WithKey set key
-func WithKey(key []byte) Option {
+func WithKey(key interface{}) Option {
 	return func(o *Options) {
 		o.keyFunc = func(token *jwtV5.Token) (interface{}, error) {
 			return key, nil


### PR DESCRIPTION
因为 RS256 是非对称加密，底层的 golang-jwt 库在执行签发 (SignedString) 时，严格要求传入的 key 必须是被解析好的 *rsa.PrivateKey 对象.